### PR TITLE
Include host component ID in default outlet selector

### DIFF
--- a/lib/vident/root_component.rb
+++ b/lib/vident/root_component.rb
@@ -69,10 +69,14 @@ module Vident
       build_target_data_attributes([target(name)])
     end
 
+    def build_outlet_selector(outlet_selector)
+      "##{@id} [data-controller~=#{outlet_selector}]"
+    end
+
     def outlet(css_selector: nil)
       controller = implied_controller_name
       if css_selector.nil?
-        [controller, "[data-controller~=#{controller}]"]
+        [controller, build_outlet_selector(controller)]
       else
         [controller, css_selector]
       end
@@ -153,13 +157,13 @@ module Vident
 
       @outlets.each_with_object({}) do |outlet_config, obj|
         identifier, css_selector = if outlet_config.is_a?(String)
-          [outlet_config, "[data-controller~=#{outlet_config}]"]
+          [outlet_config, build_outlet_selector(outlet_config)]
         elsif outlet_config.is_a?(Array)
           outlet_config[..1]
         elsif outlet_config.respond_to?(:stimulus_identifier) # Is a Component
-          [outlet_config.stimulus_identifier, "[data-controller~=#{outlet_config.stimulus_identifier}]"]
+          [outlet_config.stimulus_identifier, build_outlet_selector(outlet_config.stimulus_identifier)]
         elsif outlet_config.send(:implied_controller_name) # Is a RootComponent ?
-          [outlet_config.send(:implied_controller_name), "[data-controller~=#{outlet_config.send(:implied_controller_name)}]"]
+          [outlet_config.send(:implied_controller_name), build_outlet_selector(outlet_config.send(:implied_controller_name))]
         else
           raise ArgumentError, "Invalid outlet config: #{outlet_config}"
         end


### PR DESCRIPTION
Prior to this change, any elements in the document matching the generated selector will be attached as an outlet. This is likely not the desired behaviour in a view component setup - you probably on;ly want to attach elements that are children of the host component.

The change here scopes the generated selector to only include child elements, by using the generated ID of the host component to scope the selector.